### PR TITLE
Fixes Issue #6 - Toggle to expand rest of schema properties

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -95,6 +95,10 @@
             title: 'OpenStatus',
             url: 'https://api.openstatus.dev/v1/openapi',
           },
+          {
+            title: 'Reproducing Issue',
+            url: 'testopenapi.json',
+          },
         ],
         persistAuth: true,
         // Avoid CORS issues

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -107,6 +107,7 @@ const schema = computed(() => {
   return props.value
 })
 
+// whether to show the toggle for the schema
 const shouldShowToggle = computed(() => {
   if (props.noncollapsible || props.level === 0) {
     return false
@@ -157,7 +158,7 @@ const handleDiscriminatorChange = (type: string) => {
   <Disclosure
     v-if="typeof value === 'object' && Object.keys(value).length"
     v-slot="{ open }"
-    :defaultOpen="noncollapsible">
+    :defaultOpen="noncollapsible && !additionalProperties">
     <div
       class="schema-card"
       :class="[
@@ -180,8 +181,7 @@ const handleDiscriminatorChange = (type: string) => {
         }">
         <!-- Special toggle to show additional properties -->
         <div
-          v-if="additionalProperties"
-          v-show="!open"
+          v-if="additionalProperties && !open"
           class="schema-properties">
           <DisclosureButton
             as="button"
@@ -233,7 +233,7 @@ const handleDiscriminatorChange = (type: string) => {
         </DisclosureButton>
         <DisclosurePanel
           as="ul"
-          :static="!shouldShowToggle">
+          :static="!shouldShowToggle && !additionalProperties">
           <!-- Schema properties -->
           <template
             v-if="
@@ -371,6 +371,23 @@ const handleDiscriminatorChange = (type: string) => {
               @update:modelValue="handleDiscriminatorChange" />
           </template>
         </DisclosurePanel>
+
+        <!-- Special toggle to hide additional properties - AFTER properties (when open) -->
+        <div
+          v-if="additionalProperties && open"
+          class="schema-properties">
+          <DisclosureButton
+            as="button"
+            class="schema-card-title schema-card-title--compact"
+            @click.capture="handleClick">
+            <ScalarIcon
+              class="schema-card-title-icon schema-card-title-icon--open"
+              icon="Add"
+              size="sm" />
+            Hide additional properties
+            <ScreenReader v-if="name">for {{ name }}</ScreenReader>
+          </DisclosureButton>
+        </div>
       </div>
     </div>
   </Disclosure>

--- a/packages/api-reference/testopenapi.json
+++ b/packages/api-reference/testopenapi.json
@@ -1,0 +1,140 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/Test": {
+      "post": {
+        "summary": "Test",
+        "operationId": "Test",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestRequest": {
+        "required": ["A", "B", "C"],
+        "type": "object",
+        "properties": {
+          "A": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "B": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "C": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "D": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "E": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "F": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "G": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "H": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "I": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "J": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "K": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "L": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "M": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "N": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "O": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "P": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "Q": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "R": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "S": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "T": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "U": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "V": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "W": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "X": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "Y": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "Z": {
+            "maxLength": 50,
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Problem**

Currently, the API reference component shows all of the schema properties and 'Show additional properties' toggle button does not work properly. The toggle button is visible, but when clicked on, it disappears. This UI can confuse users due to the interactive function not working as expected. 

**Solution**

With this PR, the button is implemented to show and hide properties. The button also changes to 'Hide additional properties' when all properties are shown. With this implementation, users can properly interact with the UI to show or hide additional properties. 

**Video Walkthrough**
[Video walkthrough of the issue and the fix](https://cap.link/npt63dsc9ma0v67)

**Test suite output**
<img width="809" height="273" alt="Screenshot 2025-10-19 at 10 41 30 PM" src="https://github.com/user-attachments/assets/cc22d590-9be6-4e77-af0f-98881b59fcfb" />


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
