### PR TITLE
Fix Issue #8: Add configuration options for sorting schema properties

### DIFF
--- a/.changeset/orange-planets-mix.md
+++ b/.changeset/orange-planets-mix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': major
+---
+
+Implement new configurations (orderSchemaPropertiesBy & orderRequiredPropertiesFirst) and the logic to display the correct order of properties

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -942,6 +942,57 @@ Or specify a custom function to sort the operations.
 
 > Note: `method` is the HTTP method of the operation, represented as a lowercase string.
 
+### orderSchemaPropertiesBy?: 'alpha' | 'preserve'
+
+Controls how schema properties are sorted in the documentation. This works in combination with `orderRequiredPropertiesFirst` to determine the final display order.
+
+`@default 'alpha'`
+
+```js
+{
+  orderSchemaPropertiesBy: 'alpha' // Sort properties alphabetically
+}
+```
+
+```js
+{
+  orderSchemaPropertiesBy: 'preserve' // Preserve original order from OpenAPI spec
+}
+```
+
+**Values:**
+- `'alpha'`: Properties are sorted alphabetically
+- `'preserve'`: Properties appear in the same order as defined in the OpenAPI specification
+
+See [Schema Property Sorting Guide](./guides/schema-property-sorting.md) for detailed examples and use cases.
+
+### orderRequiredPropertiesFirst?: boolean
+
+When `true`, required properties are displayed first (in their sorted order), followed by optional properties (in their sorted order). When `false`, all properties are sorted together regardless of required status.
+
+`@default true`
+
+```js
+{
+  orderRequiredPropertiesFirst: true // Group required properties first
+}
+```
+
+```js
+{
+  orderRequiredPropertiesFirst: false // Mix required and optional properties
+}
+```
+
+This option works together with `orderSchemaPropertiesBy` to provide four different sorting combinations:
+
+1. **`alpha` + `true` (default)**: Required properties alphabetically, then optional properties alphabetically
+2. **`alpha` + `false`**: All properties alphabetically together
+3. **`preserve` + `true`**: Required properties in original order, then optional properties in original order
+4. **`preserve` + `false`**: All properties in original specification order
+
+See [Schema Property Sorting Guide](./guides/schema-property-sorting.md) for detailed examples and use cases.
+
 ### theme?: string
 
 You don't like the color scheme? We've prepared some themes for you:

--- a/documentation/guides/schema-property-sorting.md
+++ b/documentation/guides/schema-property-sorting.md
@@ -1,0 +1,341 @@
+# Schema Property Sorting
+
+This guide explains how to configure the sorting of schema properties in the API reference documentation.
+
+## Overview
+
+The schema property sorting feature allows you to control how properties are displayed in your API documentation through two independent configuration options that work together to control the final display order.
+
+## Configuration Options
+
+### `orderSchemaPropertiesBy`
+
+Controls the sorting method for properties.
+
+- **Type:** `'alpha' | 'preserve'`
+- **Default:** `'alpha'`
+
+**Values:**
+- `'alpha'`: Sort properties alphabetically
+- `'preserve'`: Preserve the original order from the OpenAPI specification
+
+### `orderRequiredPropertiesFirst`
+
+Controls whether required properties are grouped separately from optional properties.
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+**Values:**
+- `true`: Display required properties first, followed by optional properties
+- `false`: Mix required and optional properties together according to the sorting method
+
+## Configuration Combinations
+
+The two options work together to provide four distinct sorting behaviors:
+
+### Case 1: Alphabetical with Required First (Default)
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'alpha',        // default
+  orderRequiredPropertiesFirst: true       // default
+}
+```
+
+**Behavior:** Required properties sorted alphabetically, then optional properties sorted alphabetically
+
+**Example:**
+Given properties: `zebra` (required), `beta` (optional), `alpha` (optional), `gamma` (required)
+
+**Result:** `gamma`, `zebra`, `alpha`, `beta`
+
+---
+
+### Case 2: Alphabetical without Grouping
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'alpha',
+  orderRequiredPropertiesFirst: false
+}
+```
+
+**Behavior:** All properties sorted alphabetically, regardless of required status
+
+**Example:**
+Given properties: `zebra` (required), `beta` (optional), `alpha` (optional), `gamma` (required)
+
+**Result:** `alpha`, `beta`, `gamma`, `zebra`
+
+---
+
+### Case 3: Preserve Order with Required First
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'preserve',
+  orderRequiredPropertiesFirst: true
+}
+```
+
+**Behavior:** Required properties in original order, then optional properties in original order
+
+**Example:**
+Given properties: `zebra` (required), `beta` (optional), `alpha` (optional), `gamma` (required)
+
+**Result:** `zebra`, `gamma`, `beta`, `alpha`
+
+---
+
+### Case 4: Preserve Original Order
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'preserve',
+  orderRequiredPropertiesFirst: false
+}
+```
+
+**Behavior:** All properties in their original order from the OpenAPI specification
+
+**Example:**
+Given properties: `zebra` (required), `beta` (optional), `alpha` (optional), `gamma` (required)
+
+**Result:** `zebra`, `beta`, `alpha`, `gamma`
+
+## Usage Examples
+
+### Basic Setup
+
+```typescript
+import { ApiReference } from '@scalar/api-reference'
+
+ApiReference({
+  spec: {
+    url: 'https://example.com/openapi.json'
+  },
+  configuration: {
+    orderSchemaPropertiesBy: 'alpha',
+    orderRequiredPropertiesFirst: true
+  }
+})
+```
+
+### HTML/CDN Setup
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>API Reference</title>
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="https://example.com/openapi.json"
+      data-configuration='{
+        "orderSchemaPropertiesBy": "preserve",
+        "orderRequiredPropertiesFirst": false
+      }'>
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+```
+
+### React Setup
+
+```tsx
+import { ApiReferenceReact } from '@scalar/api-reference-react'
+
+function App() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        spec: {
+          url: 'https://example.com/openapi.json'
+        },
+        orderSchemaPropertiesBy: 'preserve',
+        orderRequiredPropertiesFirst: true
+      }}
+    />
+  )
+}
+```
+
+### Vue Setup
+
+```vue
+<script setup lang="ts">
+import { ApiReference } from '@scalar/api-reference'
+
+const configuration = {
+  orderSchemaPropertiesBy: 'alpha',
+  orderRequiredPropertiesFirst: false
+}
+</script>
+
+<template>
+  <ApiReference :configuration="configuration" />
+</template>
+```
+
+### Next.js Setup
+
+```typescript
+import { ApiReference } from '@scalar/api-reference'
+
+export default function Page() {
+  return (
+    <ApiReference
+      configuration={{
+        spec: {
+          url: '/api/openapi.json'
+        },
+        orderSchemaPropertiesBy: 'preserve',
+        orderRequiredPropertiesFirst: false
+      }}
+    />
+  )
+}
+```
+
+## Use Cases
+
+### Use Case 1: Consistent Alphabetical Order
+
+When you want all properties sorted alphabetically for easy scanning:
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'alpha',
+  orderRequiredPropertiesFirst: false
+}
+```
+
+**Best for:** APIs with many properties where users need to quickly find specific fields.
+
+---
+
+### Use Case 2: Highlight Required Fields
+
+When you want to emphasize which fields are required:
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'alpha',
+  orderRequiredPropertiesFirst: true  // default
+}
+```
+
+**Best for:** APIs where it's critical for users to see required fields first before optional ones.
+
+---
+
+### Use Case 3: Match Specification Order
+
+When your OpenAPI spec has a carefully crafted property order you want to maintain:
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'preserve',
+  orderRequiredPropertiesFirst: false
+}
+```
+
+**Best for:** APIs where the spec author has organized properties in a logical flow (e.g., id, name, description, metadata).
+
+---
+
+### Use Case 4: Specification Order with Required Emphasis
+
+When you want to preserve your spec's order but still highlight required fields:
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'preserve',
+  orderRequiredPropertiesFirst: true
+}
+```
+
+**Best for:** APIs with well-organized specs where required fields should still be prominent.
+
+## Technical Implementation
+
+The feature is implemented across several files:
+
+### Configuration Schema
+**File:** `packages/types/src/api-reference/api-reference-configuration.ts`
+
+Defines the configuration options with proper TypeScript types and Zod validation.
+
+### Sorting Utility
+**File:** `packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.ts`
+
+Contains the core sorting logic that handles all four configuration combinations.
+
+### Schema Component
+**File:** `packages/api-reference/src/components/Content/Schema/Schema.vue`
+
+Integrates the sorting functionality into the schema rendering component.
+
+### Unit Tests
+**File:** `packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.test.ts`
+
+Comprehensive test coverage for all sorting scenarios and edge cases.
+
+## Migration Guide
+
+### Default Behavior
+
+If you don't specify these configuration options, the default behavior is:
+- Properties are sorted alphabetically (`orderSchemaPropertiesBy: 'alpha'`)
+- Required properties appear first (`orderRequiredPropertiesFirst: true`)
+
+This provides a consistent, predictable display order across all API references.
+
+### Preserving Legacy Behavior
+
+If you want to maintain the exact order from your OpenAPI specification (matching behavior before this feature):
+
+```typescript
+{
+  orderSchemaPropertiesBy: 'preserve',
+  orderRequiredPropertiesFirst: false
+}
+```
+
+## FAQ
+
+**Q: Does this affect all schema displays?**  
+A: Yes, this configuration applies to request bodies, response schemas, and model definitions throughout the documentation.
+
+**Q: Can I use custom sorting functions?**  
+A: Currently, only `'alpha'` and `'preserve'` are supported. Custom sorting functions are not available.
+
+**Q: Does alphabetical sorting consider case sensitivity?**  
+A: The alphabetical sorting uses `localeCompare()`, which provides case-insensitive sorting by default.
+
+**Q: What happens to properties with special characters?**  
+A: Special characters are sorted according to JavaScript's `localeCompare()` rules. For example: `$special`, `_private`, `normal`, `public`.
+
+**Q: Does this work with discriminator schemas?**  
+A: Yes, the sorting applies to all schema properties, including those in discriminator schemas.
+
+**Q: Can I sort differently in different parts of the documentation?**  
+A: No, the configuration is global and applies to all schema displays in the reference.
+
+## Related Documentation
+
+- [Configuration](../configuration.md) - Full configuration reference
+- [OpenAPI](../openapi.md) - OpenAPI specification support
+- [Themes](../themes.md) - Customizing the appearance
+
+## Support
+
+If you encounter any issues with schema property sorting, please:
+1. Check that you're using the latest version of `@scalar/api-reference`
+2. Verify your configuration syntax matches the examples above
+3. Report issues on [GitHub](https://github.com/scalar/scalar/issues)
+

--- a/documentation/guides/schema-property-sorting.md
+++ b/documentation/guides/schema-property-sorting.md
@@ -305,37 +305,3 @@ If you want to maintain the exact order from your OpenAPI specification (matchin
   orderRequiredPropertiesFirst: false
 }
 ```
-
-## FAQ
-
-**Q: Does this affect all schema displays?**  
-A: Yes, this configuration applies to request bodies, response schemas, and model definitions throughout the documentation.
-
-**Q: Can I use custom sorting functions?**  
-A: Currently, only `'alpha'` and `'preserve'` are supported. Custom sorting functions are not available.
-
-**Q: Does alphabetical sorting consider case sensitivity?**  
-A: The alphabetical sorting uses `localeCompare()`, which provides case-insensitive sorting by default.
-
-**Q: What happens to properties with special characters?**  
-A: Special characters are sorted according to JavaScript's `localeCompare()` rules. For example: `$special`, `_private`, `normal`, `public`.
-
-**Q: Does this work with discriminator schemas?**  
-A: Yes, the sorting applies to all schema properties, including those in discriminator schemas.
-
-**Q: Can I sort differently in different parts of the documentation?**  
-A: No, the configuration is global and applies to all schema displays in the reference.
-
-## Related Documentation
-
-- [Configuration](../configuration.md) - Full configuration reference
-- [OpenAPI](../openapi.md) - OpenAPI specification support
-- [Themes](../themes.md) - Customizing the appearance
-
-## Support
-
-If you encounter any issues with schema property sorting, please:
-1. Check that you're using the latest version of `@scalar/api-reference`
-2. Verify your configuration syntax matches the examples above
-3. Report issues on [GitHub](https://github.com/scalar/scalar/issues)
-

--- a/memory/design/002_voice_ai_student_support_functional_requirements.md
+++ b/memory/design/002_voice_ai_student_support_functional_requirements.md
@@ -1,0 +1,377 @@
+# Voice AI Student Support System - User Scenarios
+
+## Scenario 1: First-Time Student Gets Help with API Error
+
+### Context
+**Student:** Maria, a junior developer working on her first open source contribution  
+**Project:** Scalar API Reference  
+**Issue:** #847 - Add dark mode toggle to settings panel  
+**Problem:** Getting a 404 error when trying to fetch theme preferences from API
+
+### User Journey
+
+1. **Login & Session Start**
+   - Maria logs into the web app using her email and password
+   - System loads her profile and displays "Working on: Scalar API Reference - Issue #847"
+   - She clicks "Start Voice Session" button
+   - System displays: "Hi Maria! I can see you're working on the dark mode toggle. How can I help today?"
+
+2. **Describing the Problem**
+   - Maria speaks: "I'm trying to fetch the theme preferences from the API but I keep getting a 404 error"
+   - System transcribes in real-time, showing text in the UI
+   - AI asks: "Can you tell me which endpoint you're trying to call?"
+   - Maria: "I'm using /api/preferences/theme"
+   - AI: "Let me check the project's API documentation..."
+
+3. **AI Provides Solution**
+   - AI searches knowledge bank and project README
+   - AI responds: "I found the issue. In the Scalar API Reference project, the preferences endpoint is actually /api/user/preferences and theme is a property in the response object."
+   - UI displays code snippet:
+     ```javascript
+     // Correct endpoint
+     fetch('/api/user/preferences')
+       .then(res => res.json())
+       .then(data => {
+         const theme = data.theme;
+       });
+     ```
+   - AI: "Does this make sense? Would you like me to explain how the preferences object is structured?"
+
+4. **Verification & Follow-up**
+   - Maria: "Yes, that makes sense! Let me try it."
+   - AI: "Great! Let me know if you run into any other issues."
+   - Maria clicks "End Session"
+   - System displays session summary:
+     - **Problem:** 404 error on theme API endpoint
+     - **Solution:** Use /api/user/preferences endpoint instead
+     - **Next Steps:** Update fetch call in code
+   - Summary sent to Maria's email
+
+### Outcome
+✅ Maria resolved her issue in 3 minutes  
+✅ No expert escalation needed  
+✅ Conversation saved for future reference
+
+---
+
+## Scenario 2: Student Stuck for Hours, Gets Escalated to Expert
+
+### Context
+**Student:** James, working on a complex authentication bug  
+**Project:** Express API Integration  
+**Issue:** #1203 - JWT tokens not refreshing properly  
+**Problem:** Spent 3 hours debugging, tried multiple solutions from AI
+
+### User Journey
+
+1. **Multiple Sessions Over Time**
+   - **Session 1 (Monday 2pm):** James asks about JWT refresh tokens
+     - AI provides standard JWT refresh implementation
+     - James tries it, still doesn't work
+     - Session ends after 45 minutes
+   
+   - **Session 2 (Monday 4pm):** James returns, frustrated
+     - AI: "I see we discussed JWT refresh earlier. What's happening now?"
+     - James: "The tokens are being created but the refresh endpoint returns 401"
+     - AI suggests checking middleware order and token validation
+     - James tries suggestions, session ends after 1 hour
+   
+   - **Session 3 (Tuesday 10am):** James back again
+     - AI recognizes recurring issue
+     - James: "Still getting 401 on refresh. I've checked everything you suggested"
+     - System detects: 3 sessions on same issue, 2.5+ hours total active time
+
+2. **Escalation Suggestion**
+   - AI: "I notice we've been working on this JWT refresh issue across three sessions now. The solutions I've provided haven't fully resolved it. Would you like me to escalate this to an expert who can review your code directly?"
+   - UI displays escalation prompt with button: "Yes, Get Expert Help" / "No, Keep Trying"
+   - James clicks "Yes, Get Expert Help"
+
+3. **Escalation Creation**
+   - System compiles escalation package:
+     - Student: James Chen (james@university.edu)
+     - Project: Express API Integration
+     - Issue: #1203 - JWT tokens not refreshing properly
+     - Sessions: 3 (spanning 2 days)
+     - Problem: Refresh endpoint returns 401, standard solutions not working
+     - AI Solutions Attempted:
+       - Standard JWT refresh implementation
+       - Middleware ordering checks
+       - Token validation verification
+     - Student's Code: Link to branch `james/jwt-refresh-fix`
+     - Recent Commits: Shows last 3 commits related to auth
+   
+4. **Expert Notification**
+   - System sends email to experts@university.edu
+   - System posts to Discord #escalations channel:
+     ```
+     🆘 New Escalation - Created: 2025-10-29 10:15am
+     Student: James Chen
+     Project: Express API Integration
+     Issue: JWT refresh endpoint returning 401
+     Tech: Node.js, Express, JWT
+     [View Case] [Claim Case]
+     ```
+
+5. **James Receives Confirmation**
+   - UI displays: "Your request has been sent to an expert. You'll receive an email response within 24 hours."
+   - Email sent to James with escalation summary
+   - James can continue working or end session
+
+### Outcome
+✅ System recognized when AI couldn't solve the problem  
+✅ Escalation happened at appropriate time  
+✅ Expert has full context to help effectively  
+✅ James doesn't waste more time stuck
+
+---
+
+## Scenario 3: Expert Reviews and Responds to Escalation
+
+### Context
+**Expert:** Dr. Sarah Johnson, experienced backend developer  
+**Escalated Case:** James's JWT refresh token issue  
+**Time:** Tuesday 2pm (4 hours after escalation)
+
+### User Journey
+
+1. **Expert Receives Notification**
+   - Sarah checks her email, sees escalation notification
+   - Opens Discord, sees post in #escalations channel
+   - Clicks "View Case" link to expert dashboard
+
+2. **Reviewing the Case**
+   - Expert dashboard shows:
+     ```
+     Queue (5 cases)
+     ┌────────────────────────────────────────────────────────┐
+     │ James Chen - JWT refresh 401 error                     │
+     │ Project: Express API Integration | Created: 4h ago     │
+     │ Tags: Node.js, Express, JWT, Authentication            │
+     │ Status: New                                            │
+     └────────────────────────────────────────────────────────┘
+     ```
+   - Sarah filters by "Node.js" (her expertise)
+   - Clicks on James's case
+   - Views full escalation package:
+     - Conversation history (3 sessions)
+     - AI attempted solutions
+     - James's GitHub branch link
+     - Issue #1203 details
+
+3. **Investigating the Code**
+   - Sarah clicks GitHub link to James's branch
+   - Reviews `auth.middleware.js` and `refresh.route.js`
+   - Spots the issue: James is checking for token in `req.headers.authorization` but the refresh token is sent in `req.cookies.refreshToken`
+   - This wasn't caught by AI because it's a project-specific cookie implementation
+
+4. **Responding to Student**
+   - Sarah clicks "Respond" button
+   - System opens email template pre-filled with James's email and context
+   - Sarah writes:
+     ```
+     Hi James,
+
+     I reviewed your JWT refresh implementation and found the issue. 
+     Your refresh endpoint is looking for the token in the Authorization 
+     header, but in this project, refresh tokens are stored in HTTP-only 
+     cookies.
+
+     In your refresh.route.js, change line 12 from:
+     const token = req.headers.authorization?.split(' ')[1];
+
+     To:
+     const token = req.cookies.refreshToken;
+
+     Also, make sure you have cookie-parser middleware installed and 
+     configured in your app.js.
+
+     Let me know if this works or if you need more help!
+
+     - Sarah
+     ```
+   - Sends email
+   - System logs response in case timeline
+
+5. **Creating Resolution Post**
+   - Sarah thinks this is a common issue others might face
+   - Clicks "Create Resolution Post"
+   - Fills in form:
+     - **Title:** JWT Refresh Token 401 Error with Cookie-based Authentication
+     - **Problem:** Refresh endpoint returns 401 because token location is incorrect
+     - **Solution:** 
+       ```
+       In Express projects using cookie-based auth, refresh tokens 
+       are typically stored in HTTP-only cookies, not Authorization headers.
+       
+       Check:
+       1. Token is in req.cookies.refreshToken, not req.headers.authorization
+       2. cookie-parser middleware is installed and configured
+       3. Refresh token is being set as a cookie in login endpoint
+       ```
+     - **Code Example:**
+       ```javascript
+       // In refresh.route.js
+       router.post('/refresh', (req, res) => {
+         const refreshToken = req.cookies.refreshToken; // Not from headers!
+         // ... rest of refresh logic
+       });
+       ```
+     - **Tags:** JWT, Express, Authentication, Cookies
+   - Clicks "Post Publicly"
+
+6. **Closing the Case**
+   - Sarah marks case as "Resolved"
+   - Adds private note: "Cookie vs header auth token issue. Added to Solutions Feed."
+   - Case moves from Queue to "My Resolved Cases"
+
+### Outcome
+✅ Expert quickly identified issue with full context  
+✅ Student received detailed, actionable guidance  
+✅ Solution shared publicly for other students  
+✅ Knowledge gap identified and documented
+
+---
+
+## Scenario 4: Student Finds Solution in Solutions Feed
+
+### Context
+**Student:** Lisa, working on authentication for a different project  
+**Project:** FastAPI Integration  
+**Issue:** #542 - Implement refresh token endpoint  
+**Situation:** Getting 401 errors, sounds familiar...
+
+### User Journey
+
+1. **Starting Research Before AI Session**
+   - Lisa logs into the web app
+   - Before starting a voice session, she notices "Solutions Feed" in sidebar
+   - Clicks to browse recent expert solutions
+
+2. **Searching Solutions Feed**
+   - Feed shows recent resolution posts from experts
+   - Lisa types in search box: "refresh token 401"
+   - Results show Sarah's post from yesterday: "JWT Refresh Token 401 Error with Cookie-based Authentication"
+   - Post shows: 3 bookmarks, Posted by Dr. Sarah Johnson, Tags: JWT, Express, Authentication, Cookies
+
+3. **Reading the Solution**
+   - Lisa clicks on the post
+   - Reads the problem description and solution
+   - Code example shows checking `req.cookies.refreshToken`
+   - Lisa thinks: "Wait, I'm using FastAPI with Python, but maybe it's the same concept..."
+
+4. **Adapting Solution to Her Project**
+   - Lisa starts a voice session to confirm
+   - "Hi, I just read a solution about JWT refresh tokens in cookies. I'm using FastAPI - is it the same concept?"
+   - AI: "Yes! In FastAPI, refresh tokens can also be stored in cookies. Let me show you the FastAPI equivalent..."
+   - AI provides Python/FastAPI code example
+   - Lisa implements it, problem solved!
+
+5. **Bookmarking for Future**
+   - Lisa returns to Solutions Feed
+   - Clicks "Bookmark" on Sarah's original post
+   - Post is now saved in her "Saved Solutions" list
+
+### Outcome
+✅ Lisa solved her problem without needing AI session or escalation  
+✅ Expert's solution helped multiple students across different projects  
+✅ Knowledge sharing reduced overall support load  
+✅ Solutions Feed proved valuable resource
+
+---
+
+## Scenario 5: Student Resolves Common Issue and Contributes
+
+### Context
+**Student:** Alex, experienced developer working on a tricky issue  
+**Project:** Vue Component Library  
+**Issue:** #789 - Fix reactive props not updating in nested components  
+**Situation:** Alex figures out the solution after some trial and error
+
+### User Journey
+
+1. **Working Through the Problem**
+   - Alex has 2 voice sessions with AI about Vue reactivity
+   - AI provides some standard solutions, but none quite work
+   - Alex experiments with different approaches
+   - Finally discovers the issue: needs `toRefs()` for destructured props in nested components
+
+2. **System Detects Resolution**
+   - Alex returns for 3rd session
+   - "I figured it out! The problem was destructuring props without toRefs"
+   - AI: "That's great! I'm glad you found the solution."
+   - System checks: this issue type (Vue reactive props) has appeared in 5 other student sessions recently
+
+3. **Contribution Prompt**
+   - AI: "I notice several other students have been struggling with Vue reactivity issues in nested components. Would you be willing to document your solution to help them?"
+   - UI displays: "Contribute Your Solution" button
+   - Alex clicks "Sure, I can do that"
+
+4. **Documenting the Solution**
+   - System opens contribution form pre-filled with:
+     - **Problem:** From conversation context
+     - **Your Solution:** Empty (Alex fills this in)
+   - Alex writes:
+     ```
+     Problem: Reactive props not updating in deeply nested Vue components
+     
+     When I destructured props in a nested component, changes from parent 
+     weren't triggering updates.
+     
+     Solution: Use toRefs() when destructuring props to maintain reactivity
+     
+     Before (not working):
+     const { user, settings } = props;
+     
+     After (working):
+     import { toRefs } from 'vue';
+     const { user, settings } = toRefs(props);
+     
+     Key lesson: Destructuring breaks reactivity unless you use toRefs()
+     ```
+   - Alex adds tags: Vue, Reactivity, Props, Composition API
+   - Clicks "Submit for Review"
+
+5. **Admin Review & Approval**
+   - Contribution goes to admin queue
+   - Admin (Dr. Martinez) reviews submission
+   - Validates the solution is correct
+   - Clicks "Approve and Add to Knowledge Bank"
+   - Solution is now searchable by AI and visible to all students
+
+6. **Recognition**
+   - Alex receives email: "Your contribution has been approved! Thank you for helping other students."
+   - Alex's profile shows contribution badge
+   - When AI uses this solution, it attributes to Alex: "Based on a solution from Alex..."
+
+### Outcome
+✅ Alex's hard-earned knowledge helps other students  
+✅ Knowledge bank grows organically with real student experiences  
+✅ Students incentivized to document solutions  
+✅ Community learning culture established
+
+---
+
+## Key Success Metrics Visible in Scenarios:
+
+1. **Time to Resolution**
+   - Maria: 3 minutes (AI only)
+   - James: 4 hours to escalation + expert response
+   - Lisa: < 5 minutes (self-service via Solutions Feed)
+
+2. **Knowledge Reuse**
+   - Sarah's solution → helped Lisa and 2+ other students
+   - Alex's contribution → available to all future students
+
+3. **Expert Efficiency**
+   - Sarah had full context, resolved quickly
+   - Filtering and claiming system prevents duplicate work
+
+4. **System Learning**
+   - AI learns from expert responses
+   - Knowledge bank grows from student contributions
+   - Admins identify content gaps from patterns
+
+5. **Student Satisfaction**
+   - Quick help for simple issues
+   - Human support when needed
+   - Ability to help others and contribute

--- a/memory/design/003_voice_ai_student_support_components_and_services.md
+++ b/memory/design/003_voice_ai_student_support_components_and_services.md
@@ -1,0 +1,932 @@
+# Voice AI Student Support System - Components and Services Architecture
+
+## System Overview
+
+This document defines the components and services architecture for the Voice AI Student Support System, mapped to the functional requirements and user scenarios.
+
+---
+
+## Architecture Diagram (High-Level)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          CLIENT LAYER                               │
+├─────────────────────────────────────────────────────────────────────┤
+│  Student Web App  │  Expert Dashboard  │  Admin Console            │
+└──────────┬──────────────────┬────────────────────┬─────────────────┘
+           │                  │                    │
+           └──────────────────┴────────────────────┘
+                              │
+┌─────────────────────────────▼─────────────────────────────────────┐
+│                       API GATEWAY                                  │
+│                   (Authentication, Routing)                        │
+└──────────┬─────────────────────────────────────────┬──────────────┘
+           │                                         │
+    ┌──────▼────────┐                       ┌────────▼─────────┐
+    │  Web Services │                       │  Voice Services  │
+    └──────┬────────┘                       └────────┬─────────┘
+           │                                         │
+┌──────────▼──────────────────────────────────────────▼──────────────┐
+│                     CORE SERVICES LAYER                            │
+├────────────────────────────────────────────────────────────────────┤
+│  • Conversation Service      • Knowledge Service                   │
+│  • Project Context Service   • Escalation Service                  │
+│  • Session Management        • Notification Service                │
+└──────────┬──────────────────────────────────────────┬──────────────┘
+           │                                          │
+┌──────────▼──────────────────────────────────────────▼──────────────┐
+│                   INTEGRATION LAYER                                │
+├────────────────────────────────────────────────────────────────────┤
+│  • GitHub API Client    • Gmail API Client    • Discord Client    │
+│  • Speech-to-Text API   • Text-to-Speech API  • LLM API           │
+└────────────────────────────────────────────────────────────────────┘
+           │
+┌──────────▼──────────────────────────────────────────────────────┐
+│                      DATA LAYER                                  │
+├──────────────────────────────────────────────────────────────────┤
+│  • Users DB    • Sessions DB    • Knowledge DB    • Cases DB    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. CLIENT LAYER
+
+### 1.1 Student Web App
+
+**Purpose:** Primary interface for students to interact with Voice AI
+
+**Components:**
+
+#### 1.1.1 Authentication Component
+- Login/logout forms
+- Password reset flow
+- Session token management
+- Role-based UI rendering
+
+**Maps to FR:** FR-1.1 (User Authentication)
+
+#### 1.1.2 Voice Session Component
+- Microphone access and audio capture
+- Real-time transcription display
+- Voice playback controls (pause, resume, stop)
+- Speaking pace settings (slow/normal/fast)
+- Session timer display
+
+**Maps to FR:** FR-2.1 (Speech Processing), FR-2.2 (AI Responses)
+
+#### 1.1.3 Conversation Panel
+- Message thread display (student and AI)
+- Code snippet viewer with syntax highlighting
+- Link/resource display panel
+- "End Session" button
+- Session status indicator
+
+**Maps to FR:** FR-2.2.2, FR-2.3 (Conversation Flow)
+
+#### 1.1.4 Project Context Card
+- Display assigned project name
+- Show assigned issue number and title
+- Link to GitHub repository
+- Display technology tags
+
+**Maps to FR:** FR-3.1 (GitHub Integration)
+
+#### 1.1.5 Session History Component
+- List of past conversations with timestamps
+- Resume conversation button
+- Search/filter past sessions
+- View session summaries
+
+**Maps to FR:** FR-1.3 (Conversation History)
+
+#### 1.1.6 Escalation Interface
+- "Get Expert Help" button
+- Escalation confirmation dialog
+- Escalation status tracker
+- Email thread viewer for expert communication
+
+**Maps to FR:** FR-4.1 (Escalation Triggers)
+
+#### 1.1.7 Solutions Feed Component
+- Browse public resolution posts
+- Search by tags or keywords
+- Bookmark solutions
+- View saved solutions
+
+**Maps to FR:** FR-4.5 (Resolution Posts)
+
+#### 1.1.8 Contribution Form
+- Problem/solution input fields
+- Code block editor
+- Tag selector
+- Submission preview
+- Submission status tracker
+
+**Maps to FR:** FR-3.4 (Answer Verification, Student Contributions)
+
+---
+
+### 1.2 Expert Dashboard
+
+**Purpose:** Interface for experts to manage and respond to escalated cases
+
+**Components:**
+
+#### 1.2.1 Case Queue Component
+- List view of escalated cases
+- Display: student name, project, issue summary, creation date, tags, status
+- Filter controls (technology, project, date, issue type)
+- Sort controls (date, project, status)
+- "Claim Case" action buttons
+
+**Maps to FR:** FR-4.3 (Expert Dashboard)
+
+#### 1.2.2 Case Detail View
+- Full escalation package display
+- Conversation history viewer
+- AI attempted solutions list
+- GitHub code viewer integration
+- Student profile summary
+- Case timeline
+
+**Maps to FR:** FR-4.2 (Escalation Package)
+
+#### 1.2.3 Email Response Component
+- Pre-filled email template
+- Rich text editor for response
+- Code snippet insertion tool
+- Send and track email status
+- Email thread history
+
+**Maps to FR:** FR-4.4 (Expert Communication)
+
+#### 1.2.4 Resolution Post Editor
+- Title and problem description fields
+- Solution content editor with markdown support
+- Code block editor
+- Tag selector
+- Publish to Solutions Feed button
+- Preview mode
+
+**Maps to FR:** FR-4.5 (Resolution Posts)
+
+#### 1.2.5 My Cases View
+- Filter: claimed cases vs resolved cases
+- Case status management (In Progress, Resolved, Needs Follow-up)
+- Private notes section
+- Quick actions (respond, close, reopen)
+
+**Maps to FR:** FR-4.4 (Resolution & Closure)
+
+---
+
+### 1.3 Admin Console
+
+**Purpose:** System management and knowledge bank curation
+
+**Components:**
+
+#### 1.3.1 Student Import Tool
+- CSV/JSON file upload
+- Data validation and preview
+- Bulk import execution
+- Error reporting
+
+**Maps to FR:** FR-1.1 (User Authentication)
+
+#### 1.3.2 Knowledge Bank Editor
+- CRUD operations for knowledge entries
+- Rich text/markdown editor
+- Multi-level answer fields (quick, standard, deep)
+- Tag management
+- Content versioning
+- Archive/restore functionality
+
+**Maps to FR:** FR-3.2 (Knowledge Bank)
+
+#### 1.3.3 Contribution Review Queue
+- List of pending student contributions
+- Side-by-side: original problem vs proposed solution
+- Approve/reject actions with feedback
+- Edit before approval
+- Promote to knowledge bank
+
+**Maps to FR:** FR-3.4 (Answer Verification)
+
+#### 1.3.4 System Health Dashboard
+- Integration status monitors (GitHub, Gmail, Discord)
+- API health checks
+- Reconnection tools
+- Usage statistics
+- Error logs viewer
+
+**Maps to FR:** FR-7.2 (Performance & Reliability)
+
+#### 1.3.5 User Management
+- View all users (students, experts, admins)
+- Role assignment
+- Account activation/deactivation
+- Password reset admin tool
+
+**Maps to FR:** FR-1.1.3 (Role-Based Access)
+
+---
+
+## 2. API GATEWAY
+
+**Purpose:** Central entry point for all client requests, handles authentication and routing
+
+### Components:
+
+#### 2.1 Authentication Middleware
+- JWT token validation
+- Session token issuance (24-hour expiry)
+- Role-based access control (RBAC)
+- Password hashing and verification
+- Rate limiting per user
+
+**Technology:** Express.js or FastAPI with JWT library
+
+**Maps to FR:** FR-1.1, FR-7.3 (Security & Privacy)
+
+#### 2.2 Router
+- Route definitions for all API endpoints
+- Request validation
+- Error handling
+- CORS configuration
+
+**Endpoints:**
+```
+POST   /auth/login
+POST   /auth/logout
+POST   /auth/reset-password
+
+GET    /sessions
+POST   /sessions/start
+PUT    /sessions/:id/end
+GET    /sessions/:id/transcript
+
+POST   /voice/speech-to-text
+POST   /voice/text-to-speech
+
+POST   /chat/message
+GET    /chat/history/:sessionId
+
+GET    /projects/:studentId
+GET    /github/repo/:repoId
+GET    /github/issue/:issueId
+
+GET    /knowledge/search
+GET    /knowledge/entry/:id
+POST   /knowledge/entry (admin)
+PUT    /knowledge/entry/:id (admin)
+
+POST   /escalations
+GET    /escalations (experts)
+PUT    /escalations/:id/claim
+PUT    /escalations/:id/resolve
+POST   /escalations/:id/email
+
+POST   /contributions
+GET    /contributions/pending (admin)
+PUT    /contributions/:id/approve (admin)
+
+GET    /solutions
+GET    /solutions/:id
+POST   /solutions (experts)
+POST   /solutions/:id/bookmark
+```
+
+---
+
+## 3. WEB SERVICES LAYER
+
+### 3.1 Session Management Service
+
+**Purpose:** Manage student conversation sessions
+
+**Responsibilities:**
+- Create new sessions with student ID and project context
+- Track session state (active, paused, ended)
+- Track session duration and active time
+- Store session metadata
+- Generate session summaries
+
+**APIs:**
+- `createSession(studentId, projectId)`
+- `getSession(sessionId)`
+- `updateSessionStatus(sessionId, status)`
+- `trackActiveTime(sessionId, duration)`
+- `generateSummary(sessionId)`
+
+**Maps to FR:** FR-1.2 (Session Lifecycle), FR-1.3 (Conversation History)
+
+---
+
+### 3.2 Conversation Service
+
+**Purpose:** Handle message exchange between student and AI
+
+**Responsibilities:**
+- Store conversation messages with timestamps
+- Maintain conversation context and history
+- Detect conversation patterns (off-track, repetition)
+- Generate conversation summaries
+- Extract key entities from messages
+
+**APIs:**
+- `addMessage(sessionId, role, content, metadata)`
+- `getConversationHistory(sessionId)`
+- `getConversationContext(sessionId)`
+- `detectIntent(message)`
+- `extractEntities(message)`
+- `detectOffTrack(sessionId)`
+
+**Maps to FR:** FR-2.3 (Conversation Flow), FR-5.2 (Session Documentation)
+
+---
+
+### 3.3 Knowledge Service
+
+**Purpose:** Manage and retrieve knowledge bank content
+
+**Responsibilities:**
+- Store knowledge entries with multi-level answers
+- Semantic search over knowledge base
+- Track answer usage and effectiveness
+- Filter by technology, issue type, project
+- Manage tags and metadata
+- Version control for content
+
+**APIs:**
+- `searchKnowledge(query, filters)`
+- `getKnowledgeEntry(id)`
+- `createKnowledgeEntry(data)` // admin only
+- `updateKnowledgeEntry(id, data)` // admin only
+- `trackUsage(entryId, sessionId, wasHelpful)`
+- `getRelatedEntries(entryId)`
+
+**Maps to FR:** FR-3.2 (Knowledge Bank), FR-3.3 (Answer Retrieval), FR-3.4 (Answer Verification)
+
+---
+
+### 3.4 Project Context Service
+
+**Purpose:** Fetch and manage student project and repository information
+
+**Responsibilities:**
+- Load student's assigned project and issue
+- Fetch repository metadata from GitHub
+- Analyze project structure and tech stack
+- Access student's branch and commits
+- Cache repository data (24-hour refresh)
+
+**APIs:**
+- `getProjectContext(studentId)`
+- `fetchRepositoryMetadata(repoUrl)`
+- `getStudentCode(studentId, projectId)`
+- `analyzeProjectStructure(repoUrl)`
+- `syncRepositoryData(projectId)`
+
+**Maps to FR:** FR-3.1 (GitHub Integration)
+
+---
+
+### 3.5 Escalation Service
+
+**Purpose:** Manage expert escalation workflow
+
+**Responsibilities:**
+- Detect escalation triggers
+- Compile escalation packages
+- Route to expert queue
+- Track case status and timeline
+- Store expert notes
+
+**APIs:**
+- `createEscalation(studentId, sessionId, reason)`
+- `getEscalationQueue(filters, sort)`
+- `getEscalationCase(caseId)`
+- `claimCase(caseId, expertId)`
+- `updateCaseStatus(caseId, status)`
+- `addExpertNote(caseId, note)`
+- `sendExpertEmail(caseId, emailContent)`
+- `resolveCase(caseId, resolution)`
+
+**Maps to FR:** FR-4.1 (Escalation Triggers), FR-4.2 (Escalation Package), FR-4.3 (Expert Dashboard), FR-4.4 (Expert Communication)
+
+---
+
+### 3.6 Resolution Service
+
+**Purpose:** Manage public resolution posts and solutions feed
+
+**Responsibilities:**
+- Store resolution posts from experts
+- Make posts searchable and filterable
+- Manage bookmarks
+- Track post engagement
+- Promote posts to knowledge bank
+
+**APIs:**
+- `createResolutionPost(expertId, postData)`
+- `getResolutionFeed(filters, pagination)`
+- `searchResolutions(query, tags)`
+- `getResolutionPost(postId)`
+- `bookmarkPost(userId, postId)`
+- `getUserBookmarks(userId)`
+- `promoteToKnowledgeBank(postId)` // admin only
+
+**Maps to FR:** FR-4.5 (Resolution Posts)
+
+---
+
+### 3.7 Contribution Service
+
+**Purpose:** Handle student contributions to knowledge bank
+
+**Responsibilities:**
+- Detect when student resolves common issue
+- Prompt for contribution
+- Store submissions
+- Queue for admin review
+- Approve/reject with feedback
+
+**APIs:**
+- `detectContributionOpportunity(sessionId, issueType)`
+- `createContribution(studentId, contributionData)`
+- `getPendingContributions()`
+- `reviewContribution(contributionId, decision, feedback)`
+- `convertToKnowledgeEntry(contributionId)`
+
+**Maps to FR:** FR-3.4 (Answer Verification, Student Contributions)
+
+---
+
+### 3.8 Notification Service
+
+**Purpose:** Send notifications via email and Discord
+
+**Responsibilities:**
+- Send session summaries via email
+- Send escalation notifications
+- Send expert response notifications
+- Send Discord webhooks
+- Template management
+- Delivery tracking
+
+**APIs:**
+- `sendEmail(recipient, templateId, data)`
+- `sendDiscordWebhook(channel, message, embeds)`
+- `trackDelivery(notificationId)`
+- `retryFailed(notificationId)`
+- `getNotificationHistory(userId)`
+
+**Maps to FR:** FR-4.6 (Integrations), FR-1.2 (Session summaries)
+
+---
+
+## 4. VOICE SERVICES LAYER
+
+### 4.1 Speech-to-Text Service
+
+**Purpose:** Convert student voice to text in real-time
+
+**Responsibilities:**
+- Stream audio from client
+- Transcribe using STT API (e.g., Google Speech-to-Text, Whisper)
+- Handle technical terminology
+- Return transcription with confidence scores
+
+**Technology:** WebSocket for streaming, Integration with STT API
+
+**APIs:**
+- `startTranscription(audioStream, sessionId)`
+- `getPartialTranscription(sessionId)`
+- `endTranscription(sessionId)`
+
+**Maps to FR:** FR-2.1.1 (Real-Time Speech-to-Text)
+
+---
+
+### 4.2 Text-to-Speech Service
+
+**Purpose:** Convert AI text responses to natural voice
+
+**Responsibilities:**
+- Generate speech from text
+- Support speaking pace settings
+- Emphasize technical terms
+- Stream audio to client
+
+**Technology:** Integration with TTS API (e.g., Google TTS, ElevenLabs)
+
+**APIs:**
+- `synthesizeSpeech(text, voice, pace)`
+- `streamAudio(audioData, sessionId)`
+
+**Maps to FR:** FR-2.2.1 (Natural Voice Responses)
+
+---
+
+### 4.3 Natural Language Understanding Service
+
+**Purpose:** Extract intent and entities from student messages
+
+**Responsibilities:**
+- Classify intent (question, bug_report, clarification, etc.)
+- Extract entities (file names, error codes, package names)
+- Detect sentiment/emotion
+- Identify issue type
+
+**Technology:** Integration with LLM API (OpenAI, Anthropic) or custom NLU model
+
+**APIs:**
+- `analyzeMessage(text, context)`
+- `extractIntent(text)`
+- `extractEntities(text)`
+- `detectSentiment(text)`
+
+**Maps to FR:** FR-2.1.2 (Natural Language Understanding)
+
+---
+
+### 4.4 Conversation AI Service
+
+**Purpose:** Generate AI responses using LLM
+
+**Responsibilities:**
+- Maintain conversation context
+- Query knowledge service for relevant information
+- Generate contextual responses
+- Ask clarifying questions
+- Guide problem-solving steps
+- Detect when to escalate
+
+**Technology:** Integration with LLM API (OpenAI GPT-4, Anthropic Claude)
+
+**Prompt Engineering:**
+```
+System Prompt:
+You are a helpful AI assistant supporting students working on open source projects.
+Current student: {student_name}
+Project: {project_name}
+Assigned issue: {issue_title}
+Tech stack: {technologies}
+
+Guidelines:
+- Be encouraging and patient
+- Ask clarifying questions when unclear
+- Provide code examples when helpful
+- Break down complex problems into steps
+- Reference the project's documentation
+- If stuck after 3 attempts, suggest expert escalation
+
+Conversation history:
+{history}
+
+Available knowledge:
+{knowledge_results}
+```
+
+**APIs:**
+- `generateResponse(message, context, knowledge)`
+- `generateClarifyingQuestion(message, context)`
+- `generateStepByStep(problem, context)`
+- `shouldEscalate(sessionId, history)`
+
+**Maps to FR:** FR-2.2 (AI Responses), FR-2.3 (Conversation Flow), FR-4.1 (Escalation Triggers)
+
+---
+
+## 5. INTEGRATION LAYER
+
+### 5.1 GitHub API Client
+
+**Purpose:** Interface with GitHub API for repository access
+
+**Responsibilities:**
+- OAuth authentication
+- Fetch repository data (README, structure, files)
+- Fetch issue details
+- Access branches and commits
+- Rate limit handling
+
+**Technology:** Octokit (GitHub API client library)
+
+**APIs:**
+- `authenticate(token)`
+- `getRepository(owner, repo)`
+- `getIssue(owner, repo, issueNumber)`
+- `getBranch(owner, repo, branch)`
+- `getCommits(owner, repo, branch, since)`
+- `getFileContents(owner, repo, path)`
+
+**Maps to FR:** FR-3.1 (GitHub Integration), FR-4.6 (Integrations)
+
+---
+
+### 5.2 Gmail API Client
+
+**Purpose:** Send emails via Gmail API
+
+**Responsibilities:**
+- OAuth authentication
+- Send templated emails
+- Track delivery status
+- Handle rate limits
+
+**Technology:** Gmail API client library
+
+**APIs:**
+- `authenticate(credentials)`
+- `sendEmail(to, subject, body, html)`
+- `sendBulkEmails(recipients, template, data)`
+- `getDeliveryStatus(messageId)`
+
+**Maps to FR:** FR-4.6 (Integrations)
+
+---
+
+### 5.3 Discord Webhook Client
+
+**Purpose:** Post notifications to Discord channels
+
+**Responsibilities:**
+- Send webhook messages
+- Format embeds (rich messages)
+- Include action buttons
+- Handle failures gracefully
+
+**Technology:** Discord Webhook API
+
+**APIs:**
+- `sendWebhook(webhookUrl, message)`
+- `sendEmbed(webhookUrl, embed)`
+- `retryFailedWebhook(webhookId)`
+
+**Maps to FR:** FR-4.6 (Integrations)
+
+---
+
+### 5.4 LLM API Client
+
+**Purpose:** Interface with Large Language Model APIs
+
+**Responsibilities:**
+- Send prompts with context
+- Handle streaming responses
+- Manage API keys and rate limits
+- Retry logic for failures
+
+**Technology:** OpenAI SDK, Anthropic SDK
+
+**APIs:**
+- `chat(messages, model, maxTokens)`
+- `chatStream(messages, model, maxTokens)`
+- `embed(text)` // for semantic search
+
+**Maps to FR:** FR-2.2 (AI Responses), FR-3.3 (Answer Retrieval - semantic search)
+
+---
+
+## 6. DEPLOYMENT ARCHITECTURE
+
+### 6.1 Infrastructure Components
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      LOAD BALANCER                          │
+└─────────────────┬───────────────────────────────────────────┘
+                  │
+    ┌─────────────┼─────────────┐
+    │             │             │
+┌───▼────┐   ┌────▼───┐   ┌────▼───┐
+│ Web    │   │ Web    │   │ Web    │
+│ Server │   │ Server │   │ Server │  (Horizontal Scaling)
+│ (Node) │   │ (Node) │   │ (Node) │
+└───┬────┘   └────┬───┘   └────┬───┘
+    │             │             │
+    └─────────────┼─────────────┘
+                  │
+         ┌────────▼──────────┐
+         │  API Gateway      │
+         │  (Express/FastAPI)│
+         └────────┬──────────┘
+                  │
+    ┌─────────────┼──────────────┐
+    │             │              │
+┌───▼─────┐  ┌────▼────┐   ┌────▼─────┐
+│ Core    │  │ Voice   │   │ Worker   │
+│ Services│  │ Services│   │ Queue    │
+└───┬─────┘  └────┬────┘   └────┬─────┘
+    │             │              │
+    └─────────────┼──────────────┘
+                  │
+    ┌─────────────┼──────────────┬──────────────┐
+    │             │              │              │
+┌───▼───┐   ┌─────▼─────┐  ┌────▼─────┐  ┌────▼─────┐
+│Postgres│  │ Redis     │  │S3/Blob   │  │External  │
+│ DB     │  │ (Cache)   │  │(Audio)   │  │APIs      │
+└────────┘  └───────────┘  └──────────┘  └──────────┘
+```
+
+### 6.2 Technology Stack Recommendations
+
+**Frontend:**
+- Framework: React or Vue.js
+- Voice: Web Audio API, MediaRecorder API
+- State: Redux or Zustand
+- UI: Tailwind CSS or Material-UI
+
+**Backend:**
+- API: Node.js (Express) or Python (FastAPI)
+- Real-time: Socket.io or WebSockets
+- Queue: Bull (Redis-based) for async jobs
+
+**Database:**
+- Primary: PostgreSQL (relational data)
+- Cache: Redis (sessions, frequent queries)
+- Search: Elasticsearch (semantic search on knowledge bank)
+
+**Storage:**
+- Audio files: AWS S3 or Azure Blob Storage
+- Transcripts: PostgreSQL JSONB
+
+**Voice/AI:**
+- STT: Google Speech-to-Text or OpenAI Whisper
+- TTS: Google Text-to-Speech or ElevenLabs
+- LLM: OpenAI GPT-4 or Anthropic Claude
+- Embeddings: OpenAI Embeddings for semantic search
+
+**Integrations:**
+- GitHub: Octokit SDK
+- Email: Gmail API or SendGrid
+- Discord: Discord.js Webhooks
+
+---
+
+## 7. DATA FLOW EXAMPLES
+
+### 7.1 Student Starts Voice Session
+
+```
+1. Student clicks "Start Voice Session" in Web App
+2. Web App → API Gateway: POST /sessions/start
+3. API Gateway authenticates request
+4. API Gateway → Session Service: createSession(studentId)
+5. Session Service → Project Context Service: getProjectContext(studentId)
+6. Project Context Service → GitHub Client: fetch repo & issue data
+7. GitHub Client returns project data
+8. Session Service creates session record in DB
+9. Session Service returns sessionId to Web App
+10. Web App establishes WebSocket connection for voice
+11. Web App displays: "Hi [name]! Working on [project] - [issue]. How can I help?"
+```
+
+### 7.2 Student Asks Question (Voice)
+
+```
+1. Student speaks into microphone
+2. Web App captures audio stream
+3. Web App → STT Service (WebSocket): audio chunks
+4. STT Service → Speech-to-Text API: transcribe
+5. STT Service → Web App: partial transcription (real-time)
+6. Student finishes speaking
+7. STT Service → Web App: final transcription
+8. Web App → API Gateway: POST /chat/message {sessionId, message}
+9. API Gateway → Conversation Service: addMessage(sessionId, 'student', message)
+10. Conversation Service → NLU Service: analyzeMessage(message, context)
+11. NLU Service returns intent & entities
+12. Conversation Service → Knowledge Service: searchKnowledge(query, projectTags)
+13. Knowledge Service → LLM API: semantic search using embeddings
+14. Knowledge Service returns relevant entries
+15. Conversation Service → Conversation AI: generateResponse(message, context, knowledge)
+16. Conversation AI → LLM API: generate answer with prompt
+17. LLM API returns AI response text
+18. Conversation Service stores AI message in DB
+19. Conversation Service → Web App: AI response text
+20. Web App → TTS Service: synthesizeSpeech(text, pace)
+21. TTS Service → TTS API: generate audio
+22. TTS Service → Web App: audio stream
+23. Web App plays audio and displays text + code snippets
+```
+
+### 7.3 Escalation Triggered
+
+```
+1. Conversation Service detects trigger (3+ sessions or 2+ hours)
+2. Conversation Service → Web App: suggest escalation
+3. Web App displays prompt: "Get Expert Help?"
+4. Student clicks "Yes"
+5. Web App → API Gateway: POST /escalations {sessionId, reason}
+6. API Gateway → Escalation Service: createEscalation(studentId, sessionId)
+7. Escalation Service → Session Service: get session history
+8. Escalation Service → Conversation Service: get messages & summary
+9. Escalation Service → Project Context Service: get code & commits
+10. Escalation Service compiles escalation package
+11. Escalation Service stores case in DB
+12. Escalation Service → Notification Service: notify experts
+13. Notification Service → Gmail Client: send email to experts
+14. Notification Service → Discord Client: post to #escalations channel
+15. Escalation Service → Web App: "Expert notified. You'll hear back within 24h"
+16. Web App displays confirmation
+```
+
+### 7.4 Expert Claims and Responds
+
+```
+1. Expert receives email notification
+2. Expert clicks "View Case" link → Expert Dashboard
+3. Expert Dashboard → API Gateway: GET /escalations/:id
+4. API Gateway → Escalation Service: getEscalationCase(id)
+5. Escalation Service returns full case data
+6. Expert reviews case, clicks "Claim"
+7. Expert Dashboard → API Gateway: PUT /escalations/:id/claim
+8. API Gateway → Escalation Service: claimCase(id, expertId)
+9. Escalation Service updates case status to 'in_progress'
+10. Expert clicks "Respond"
+11. Expert Dashboard opens email template with pre-filled data
+12. Expert writes response and clicks "Send"
+13. Expert Dashboard → API Gateway: POST /escalations/:id/email {content}
+14. API Gateway → Escalation Service: sendExpertEmail(caseId, content)
+15. Escalation Service stores email in DB
+16. Escalation Service → Notification Service: send email to student
+17. Notification Service → Gmail Client: send email
+18. Student receives email with expert guidance
+```
+
+---
+
+## 8. SCALABILITY CONSIDERATIONS
+
+### 8.1 Horizontal Scaling
+- **Web servers:** Scale behind load balancer
+- **API Gateway:** Stateless, easy to replicate
+- **Services:** Deploy as microservices, scale independently
+- **Database:** Read replicas for queries, write to primary
+
+### 8.2 Caching Strategy
+- **Redis cache:** Session data, frequent knowledge queries
+- **CDN:** Static assets (Web App bundles, images)
+- **Service-level cache:** Repository metadata (24h TTL)
+
+### 8.3 Async Processing
+- **Worker queues:** Email sending, Discord webhooks, repo syncing
+- **Background jobs:** Session summary generation, knowledge bank analytics
+- **Scheduled tasks:** Daily repo sync, weekly metrics reports
+
+### 8.4 Rate Limiting
+- **API Gateway:** Rate limit per user (100 req/min)
+- **External APIs:** Respect GitHub, OpenAI, Google API limits
+- **Retry logic:** Exponential backoff for failed requests
+
+---
+
+## 9. SECURITY MEASURES
+
+### 9.1 Authentication & Authorization
+- **JWT tokens:** 24-hour expiry, refresh token rotation
+- **Password hashing:** bcrypt with salt
+- **RBAC:** Role-based access control for all endpoints
+- **OAuth:** Secure GitHub integration
+
+### 9.2 Data Protection
+- **Encryption in transit:** HTTPS/TLS for all connections
+- **Encryption at rest:** Database encryption, encrypted S3 buckets
+- **PII handling:** Anonymize logs, comply with FERPA
+- **Audit logs:** Track all data access
+
+### 9.3 API Security
+- **Input validation:** Sanitize all user inputs
+- **SQL injection prevention:** Parameterized queries
+- **XSS prevention:** Content Security Policy headers
+- **CORS:** Whitelist allowed origins
+
+---
+
+## Summary
+
+This architecture provides:
+
+✅ **Modular design** - Components can be developed and deployed independently  
+✅ **Scalable** - Horizontal scaling, caching, async processing  
+✅ **Maintainable** - Clear separation of concerns, well-defined APIs  
+✅ **Secure** - Authentication, encryption, access control  
+✅ **Observable** - Logging, monitoring, audit trails  
+✅ **Extensible** - Easy to add new integrations or features  
+
+### Next Steps:
+1. **MVP Focus:** Start with core components (Auth, Sessions, Conversation, Knowledge, GitHub)
+2. **Phase 1:** Add Voice services and basic AI conversation
+3. **Phase 2:** Add Escalation and Expert dashboard
+4. **Phase 3:** Add Contributions and Resolution posts
+5. **Phase 4:** Optimize, scale, and add analytics
+
+Would you like me to create:
+1. Detailed API specifications for each service?
+2. Database migration scripts?
+3. Implementation roadmap with sprints?
+4. Wireframes for key UI components?
+

--- a/packages/api-reference/TESTING-SCHEMA-SORTING.md
+++ b/packages/api-reference/TESTING-SCHEMA-SORTING.md
@@ -1,0 +1,157 @@
+# Manual Testing Guide: Schema Property Sorting
+
+## Setup Complete ✅
+
+The development environment is ready for manual testing of the schema property sorting feature.
+
+## Test Files Created
+
+1. **`issue3openapi.json`** - Test OpenAPI specification with properties in specific order:
+   - Original order: `zebra`, `beta`, `alpha`, `gamma`
+   - Required properties: `gamma`, `zebra`
+   - Optional properties: `alpha`, `beta`
+
+2. **`index.html`** - Updated with 4 test configurations for all sorting combinations
+
+## Running the Tests
+
+### Step 1: Start the Dev Server
+
+The dev server should already be running. If not, run:
+
+```bash
+cd packages/api-reference
+pnpm dev
+```
+
+### Step 2: Open in Browser
+
+Navigate to: **http://localhost:5173** (or the port shown in your terminal)
+
+### Step 3: Test Each Configuration
+
+You'll see 4 different configurations in the document selector. Switch between them to verify the sorting behavior:
+
+#### **Test 1: Alpha + Required First (Default)**
+- **Configuration:** `orderSchemaPropertiesBy: 'alpha'`, `orderRequiredPropertiesFirst: true`
+- **Expected Order:** `gamma`, `zebra`, `alpha`, `beta`
+- **Explanation:** Required properties (gamma, zebra) sorted alphabetically, then optional properties (alpha, beta) sorted alphabetically
+
+#### **Test 2: Alpha + Mixed**
+- **Configuration:** `orderSchemaPropertiesBy: 'alpha'`, `orderRequiredPropertiesFirst: false`
+- **Expected Order:** `alpha`, `beta`, `gamma`, `zebra`
+- **Explanation:** All properties sorted alphabetically together, ignoring required status
+
+#### **Test 3: Preserve + Required First**
+- **Configuration:** `orderSchemaPropertiesBy: 'preserve'`, `orderRequiredPropertiesFirst: true`
+- **Expected Order:** `zebra`, `gamma`, `beta`, `alpha`
+- **Explanation:** Required properties (zebra, gamma) in original order, then optional properties (beta, alpha) in original order
+
+#### **Test 4: Preserve + Mixed**
+- **Configuration:** `orderSchemaPropertiesBy: 'preserve'`, `orderRequiredPropertiesFirst: false`
+- **Expected Order:** `zebra`, `beta`, `alpha`, `gamma`
+- **Explanation:** All properties in their original order from the OpenAPI spec
+
+## What to Verify
+
+For each test configuration, check:
+
+### 1. Request Body Schema
+- Navigate to `POST /test` endpoint
+- Expand the request body section
+- Verify the properties are in the expected order
+- Check that required properties are marked with the required indicator
+
+### 2. Response Schema
+- Check the 200 response schema
+- Verify properties match the expected order
+
+### 3. Models Section
+- If models are visible in the sidebar, check the `TestModel` schema
+- Verify the property order matches the configuration
+
+### 4. Nested Schemas
+- Navigate to `POST /complex-test` endpoint
+- Check that nested object properties are also sorted correctly
+- Verify the `user` object properties follow the sorting rules
+
+## Visual Verification Checklist
+
+✅ Properties appear in the correct order for each configuration
+✅ Required properties are visually distinguished (marked with required indicator)
+✅ Sorting is applied consistently across all schemas in the document
+✅ Nested object properties are also sorted correctly
+✅ Switching between configurations updates the property order immediately
+✅ No console errors appear
+
+## Test Results Documentation
+
+### Test 1: Alpha + Required First
+- [ ] Request body properties: `gamma`, `zebra`, `alpha`, `beta` ✓
+- [ ] Response properties: `gamma`, `zebra`, `alpha`, `beta` ✓
+- [ ] Model properties: `gamma`, `zebra`, `alpha`, `beta` ✓
+
+### Test 2: Alpha + Mixed
+- [ ] Request body properties: `alpha`, `beta`, `gamma`, `zebra` ✓
+- [ ] Response properties: `alpha`, `beta`, `gamma`, `zebra` ✓
+- [ ] Model properties: `alpha`, `beta`, `gamma`, `zebra` ✓
+
+### Test 3: Preserve + Required First
+- [ ] Request body properties: `zebra`, `gamma`, `beta`, `alpha` ✓
+- [ ] Response properties: `zebra`, `gamma`, `beta`, `alpha` ✓
+- [ ] Model properties: `zebra`, `gamma`, `beta`, `alpha` ✓
+
+### Test 4: Preserve + Mixed
+- [ ] Request body properties: `zebra`, `beta`, `alpha`, `gamma` ✓
+- [ ] Response properties: `zebra`, `beta`, `alpha`, `gamma` ✓
+- [ ] Model properties: `zebra`, `beta`, `alpha`, `gamma` ✓
+
+## Unit Tests Status
+
+All unit tests passing: ✅
+
+```bash
+pnpm test packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.test.ts --run
+```
+
+**Result:** 12 tests passed (12)
+- Case 1: alpha + orderRequiredPropertiesFirst - 3 tests ✓
+- Case 2: alpha + !orderRequiredPropertiesFirst - 1 test ✓
+- Case 3: preserve + orderRequiredPropertiesFirst - 2 tests ✓
+- Case 4: preserve + !orderRequiredPropertiesFirst - 1 test ✓
+- Edge cases - 5 tests ✓
+
+## Troubleshooting
+
+### Properties not sorting correctly
+1. Check browser console for errors
+2. Verify the configuration values in the document selector
+3. Try hard refresh (Cmd/Ctrl + Shift + R)
+
+### Configuration not applying
+1. Ensure the dev server is running
+2. Check that you've selected the correct document from the selector
+3. Verify the configuration in `index.html` is correct
+
+### Can't see the test specifications
+1. Make sure `issue3openapi.json` is in the `packages/api-reference/` directory
+2. Check browser network tab for 404 errors
+3. Verify the file is valid JSON
+
+## Next Steps
+
+After manual testing is complete:
+1. Document any issues found
+2. Test with real-world OpenAPI specifications
+3. Verify the feature works across different browsers
+4. Consider edge cases with deeply nested schemas
+
+## Files Modified for Testing
+
+- `packages/api-reference/index.html` - Test configurations
+- `packages/api-reference/issue3openapi.json` - Test specification
+- `packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.ts` - Sorting logic
+- `packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.test.ts` - Unit tests
+- `packages/api-reference/src/components/Content/Schema/Schema.vue` - Integration
+- `packages/types/src/api-reference/api-reference-configuration.ts` - Configuration schema
+

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -95,6 +95,10 @@
             title: 'OpenStatus',
             url: 'https://api.openstatus.dev/v1/openapi',
           },
+          {
+            title: 'Reproducing Issue',
+            url: 'openapi.json',
+          },
         ],
         persistAuth: true,
         // Avoid CORS issues

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -18,47 +18,45 @@
 
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
-      Scalar.createApiReference('#app', [
-        {
-          sources: [
-            {
-              title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
-              slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
-              url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-            },
-            {
-              title: 'Swagger Petstore 2.0',
-              url: 'https://petstore.swagger.io/v2/swagger.json',
-            },
-            {
-              title: 'Swagger Petstore 3.0',
-              url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-            },
-            {
-              title: 'Swagger Petstore 3.1',
-              url: 'https://petstore31.swagger.io/api/v31/openapi.json',
-            },
-            {
-              title: 'Hello World (string)',
-              content: JSON.stringify({
-                openapi: '3.0.0',
-                info: {
-                  title: 'Hello World',
-                  version: '1.0.0',
-                },
-                paths: {
-                  '/hello': {
-                    get: {
-                      summary: 'Hello World',
-                      description: 'Hello World',
-                      responses: {
-                        200: {
-                          description: 'Hello World',
-                          content: {
-                            'application/json': {
-                              schema: {
-                                type: 'string',
-                              },
+      Scalar.createApiReference('#app', {
+        sources: [
+          {
+            title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
+            slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          },
+          {
+            title: 'Swagger Petstore 2.0',
+            url: 'https://petstore.swagger.io/v2/swagger.json',
+          },
+          {
+            title: 'Swagger Petstore 3.0',
+            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          },
+          {
+            title: 'Swagger Petstore 3.1',
+            url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+          },
+          {
+            title: 'Hello World (string)',
+            content: JSON.stringify({
+              openapi: '3.0.0',
+              info: {
+                title: 'Hello World',
+                version: '1.0.0',
+              },
+              paths: {
+                '/hello': {
+                  get: {
+                    summary: 'Hello World',
+                    description: 'Hello World',
+                    responses: {
+                      200: {
+                        description: 'Hello World',
+                        content: {
+                          'application/json': {
+                            schema: {
+                              type: 'string',
                             },
                           },
                         },
@@ -66,85 +64,77 @@
                     },
                   },
                 },
-              }),
-            },
-            {
-              title: 'Valtown',
-              url: 'https://docs.val.town/openapi.documented.json',
-            },
-            {
-              title: 'Zoom',
-              url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
-            },
-            {
-              title: 'Cloudinary',
-              url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
-            },
-            {
-              title: 'Tailscale',
-              url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
-            },
-            {
-              title: 'Maersk',
-              url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
-            },
-            {
-              title: 'Bolt',
-              url: 'https://assets.bolt.com/external-api-references/bolt.yml',
-            },
-            {
-              title: 'OpenStatus',
-              url: 'https://api.openstatus.dev/v1/openapi',
-            },
-            {
-              title: 'Reproducing Issue',
-              url: 'openapi.json',
-            },
-          ],
-          persistAuth: true,
-          proxyUrl: 'https://proxy.scalar.com',
-        },
-        // Test 1: Alpha + Required First (Default)
-        {
-          title: 'Test 1: Alpha + Required First (Default)',
-          slug: 'test-alpha-required-first',
-          url: 'issue3openapi.json',
-          orderSchemaPropertiesBy: 'alpha',
-          orderRequiredPropertiesFirst: true,
-          persistAuth: true,
-          proxyUrl: 'https://proxy.scalar.com',
-        },
-        // Test 2: Alpha + Mixed
-        {
-          title: 'Test 2: Alpha + Mixed',
-          slug: 'test-alpha-mixed',
-          url: 'issue3openapi.json',
-          orderSchemaPropertiesBy: 'alpha',
-          orderRequiredPropertiesFirst: false,
-          persistAuth: true,
-          proxyUrl: 'https://proxy.scalar.com',
-        },
-        // Test 3: Preserve + Required First
-        {
-          title: 'Test 3: Preserve + Required First',
-          slug: 'test-preserve-required-first',
-          url: 'issue3openapi.json',
-          orderSchemaPropertiesBy: 'preserve',
-          orderRequiredPropertiesFirst: true,
-          persistAuth: true,
-          proxyUrl: 'https://proxy.scalar.com',
-        },
-        // Test 4: Preserve + Mixed
-        {
-          title: 'Test 4: Preserve + Mixed',
-          slug: 'test-preserve-mixed',
-          url: 'issue3openapi.json',
-          orderSchemaPropertiesBy: 'preserve',
-          orderRequiredPropertiesFirst: false,
-          persistAuth: true,
-          proxyUrl: 'https://proxy.scalar.com',
-        },
-      ])
+              },
+            }),
+          },
+          {
+            title: 'Valtown',
+            url: 'https://docs.val.town/openapi.documented.json',
+          },
+          {
+            title: 'Zoom',
+            url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
+          },
+          {
+            title: 'Cloudinary',
+            url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
+          },
+          {
+            title: 'Tailscale',
+            url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
+          },
+          {
+            title: 'Maersk',
+            url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
+          },
+          {
+            title: 'Bolt',
+            url: 'https://assets.bolt.com/external-api-references/bolt.yml',
+          },
+          {
+            title: 'OpenStatus',
+            url: 'https://api.openstatus.dev/v1/openapi',
+          },
+          {
+            title: 'Reproducing Issue',
+            url: 'openapi.json',
+          },
+          // Test 1: Alpha + Required First (Default)
+          {
+            title: 'Test 1: Alpha + Required First (Default)',
+            slug: 'test-alpha-required-first',
+            url: 'issue3openapi.json',
+            orderSchemaPropertiesBy: 'alpha',
+            orderRequiredPropertiesFirst: true,
+          },
+          // Test 2: Alpha + Mixed
+          {
+            title: 'Test 2: Alpha + Mixed',
+            slug: 'test-alpha-mixed',
+            url: 'issue3openapi.json',
+            orderSchemaPropertiesBy: 'alpha',
+            orderRequiredPropertiesFirst: false,
+          },
+          // Test 3: Preserve + Required First
+          {
+            title: 'Test 3: Preserve + Required First',
+            slug: 'test-preserve-required-first',
+            url: 'issue3openapi.json',
+            orderSchemaPropertiesBy: 'preserve',
+            orderRequiredPropertiesFirst: true,
+          },
+          // Test 4: Preserve + Mixed
+          {
+            title: 'Test 4: Preserve + Mixed',
+            slug: 'test-preserve-mixed',
+            url: 'issue3openapi.json',
+            orderSchemaPropertiesBy: 'preserve',
+            orderRequiredPropertiesFirst: false,
+          },
+        ],
+        persistAuth: true,
+        proxyUrl: 'https://proxy.scalar.com',
+      })
     </script>
   </body>
 </html>

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -18,45 +18,47 @@
 
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
-      Scalar.createApiReference('#app', {
-        sources: [
-          {
-            title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
-            slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-          },
-          {
-            title: 'Swagger Petstore 2.0',
-            url: 'https://petstore.swagger.io/v2/swagger.json',
-          },
-          {
-            title: 'Swagger Petstore 3.0',
-            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-          },
-          {
-            title: 'Swagger Petstore 3.1',
-            url: 'https://petstore31.swagger.io/api/v31/openapi.json',
-          },
-          {
-            title: 'Hello World (string)',
-            content: JSON.stringify({
-              openapi: '3.0.0',
-              info: {
-                title: 'Hello World',
-                version: '1.0.0',
-              },
-              paths: {
-                '/hello': {
-                  get: {
-                    summary: 'Hello World',
-                    description: 'Hello World',
-                    responses: {
-                      200: {
-                        description: 'Hello World',
-                        content: {
-                          'application/json': {
-                            schema: {
-                              type: 'string',
+      Scalar.createApiReference('#app', [
+        {
+          sources: [
+            {
+              title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
+              slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
+              url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+            },
+            {
+              title: 'Swagger Petstore 2.0',
+              url: 'https://petstore.swagger.io/v2/swagger.json',
+            },
+            {
+              title: 'Swagger Petstore 3.0',
+              url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+            },
+            {
+              title: 'Swagger Petstore 3.1',
+              url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+            },
+            {
+              title: 'Hello World (string)',
+              content: JSON.stringify({
+                openapi: '3.0.0',
+                info: {
+                  title: 'Hello World',
+                  version: '1.0.0',
+                },
+                paths: {
+                  '/hello': {
+                    get: {
+                      summary: 'Hello World',
+                      description: 'Hello World',
+                      responses: {
+                        200: {
+                          description: 'Hello World',
+                          content: {
+                            'application/json': {
+                              schema: {
+                                type: 'string',
+                              },
                             },
                           },
                         },
@@ -64,46 +66,85 @@
                     },
                   },
                 },
-              },
-            }),
-          },
-          {
-            title: 'Valtown',
-            url: 'https://docs.val.town/openapi.documented.json',
-          },
-          {
-            title: 'Zoom',
-            url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
-          },
-          {
-            title: 'Cloudinary',
-            url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
-          },
-          {
-            title: 'Tailscale',
-            url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
-          },
-          {
-            title: 'Maersk',
-            url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
-          },
-          {
-            title: 'Bolt',
-            url: 'https://assets.bolt.com/external-api-references/bolt.yml',
-          },
-          {
-            title: 'OpenStatus',
-            url: 'https://api.openstatus.dev/v1/openapi',
-          },
-          {
-            title: 'Reproducing Issue',
-            url: 'openapi.json',
-          },
-        ],
-        persistAuth: true,
-        // Avoid CORS issues
-        proxyUrl: 'https://proxy.scalar.com',
-      })
+              }),
+            },
+            {
+              title: 'Valtown',
+              url: 'https://docs.val.town/openapi.documented.json',
+            },
+            {
+              title: 'Zoom',
+              url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
+            },
+            {
+              title: 'Cloudinary',
+              url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
+            },
+            {
+              title: 'Tailscale',
+              url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
+            },
+            {
+              title: 'Maersk',
+              url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
+            },
+            {
+              title: 'Bolt',
+              url: 'https://assets.bolt.com/external-api-references/bolt.yml',
+            },
+            {
+              title: 'OpenStatus',
+              url: 'https://api.openstatus.dev/v1/openapi',
+            },
+            {
+              title: 'Reproducing Issue',
+              url: 'openapi.json',
+            },
+          ],
+          persistAuth: true,
+          proxyUrl: 'https://proxy.scalar.com',
+        },
+        // Test 1: Alpha + Required First (Default)
+        {
+          title: 'Test 1: Alpha + Required First (Default)',
+          slug: 'test-alpha-required-first',
+          url: 'issue3openapi.json',
+          orderSchemaPropertiesBy: 'alpha',
+          orderRequiredPropertiesFirst: true,
+          persistAuth: true,
+          proxyUrl: 'https://proxy.scalar.com',
+        },
+        // Test 2: Alpha + Mixed
+        {
+          title: 'Test 2: Alpha + Mixed',
+          slug: 'test-alpha-mixed',
+          url: 'issue3openapi.json',
+          orderSchemaPropertiesBy: 'alpha',
+          orderRequiredPropertiesFirst: false,
+          persistAuth: true,
+          proxyUrl: 'https://proxy.scalar.com',
+        },
+        // Test 3: Preserve + Required First
+        {
+          title: 'Test 3: Preserve + Required First',
+          slug: 'test-preserve-required-first',
+          url: 'issue3openapi.json',
+          orderSchemaPropertiesBy: 'preserve',
+          orderRequiredPropertiesFirst: true,
+          persistAuth: true,
+          proxyUrl: 'https://proxy.scalar.com',
+        },
+        // Test 4: Preserve + Mixed
+        {
+          title: 'Test 4: Preserve + Mixed',
+          slug: 'test-preserve-mixed',
+          url: 'issue3openapi.json',
+          orderSchemaPropertiesBy: 'preserve',
+          orderRequiredPropertiesFirst: false,
+          persistAuth: true,
+          proxyUrl: 'https://proxy.scalar.com',
+        },
+      ])
     </script>
   </body>
 </html>

--- a/packages/api-reference/issue3openapi.json
+++ b/packages/api-reference/issue3openapi.json
@@ -1,0 +1,164 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Schema Property Sorting Test API",
+    "version": "1.0.0",
+    "description": "Test API for verifying schema property sorting functionality with different configurations"
+  },
+  "paths": {
+    "/test": {
+      "post": {
+        "summary": "Test endpoint with sorted schema",
+        "description": "This endpoint demonstrates how schema properties are sorted based on configuration",
+        "operationId": "testSorting",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["gamma", "zebra"],
+                "properties": {
+                  "zebra": {
+                    "type": "string",
+                    "description": "Required property (1st in original order)"
+                  },
+                  "beta": {
+                    "type": "string",
+                    "description": "Optional property (2nd in original order)"
+                  },
+                  "alpha": {
+                    "type": "string",
+                    "description": "Optional property (3rd in original order)"
+                  },
+                  "gamma": {
+                    "type": "string",
+                    "description": "Required property (4th in original order)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["gamma", "zebra"],
+                  "properties": {
+                    "zebra": {
+                      "type": "string",
+                      "description": "Required property (1st in original order)"
+                    },
+                    "beta": {
+                      "type": "string",
+                      "description": "Optional property (2nd in original order)"
+                    },
+                    "alpha": {
+                      "type": "string",
+                      "description": "Optional property (3rd in original order)"
+                    },
+                    "gamma": {
+                      "type": "string",
+                      "description": "Required property (4th in original order)"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/complex-test": {
+      "post": {
+        "summary": "Complex schema with nested objects",
+        "description": "Tests sorting with nested schemas",
+        "operationId": "complexSorting",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["user", "timestamp"],
+                "properties": {
+                  "user": {
+                    "type": "object",
+                    "required": ["email"],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "User's full name (optional)"
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "User's email address (required)"
+                      },
+                      "age": {
+                        "type": "integer",
+                        "description": "User's age (optional)"
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "timestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the request was created (required)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestModel": {
+        "type": "object",
+        "required": ["gamma", "zebra"],
+        "properties": {
+          "zebra": {
+            "type": "string",
+            "description": "Required property (1st in original order)"
+          },
+          "beta": {
+            "type": "string",
+            "description": "Optional property (2nd in original order)"
+          },
+          "alpha": {
+            "type": "string",
+            "description": "Optional property (3rd in original order)"
+          },
+          "gamma": {
+            "type": "string",
+            "description": "Required property (4th in original order)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api-reference/openapi.json
+++ b/packages/api-reference/openapi.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+    "description": "API with test endpoint"
+  },
+  "paths": {
+    "/Test": {
+      "post": {
+        "summary": "Test",
+        "operationId": "Test",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TestRequest": {
+        "required": ["zebra", "gamma"],
+        "type": "object",
+        "properties": {
+          "zebra": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "beta": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "alpha": {
+            "maxLength": 50,
+            "type": "string"
+          },
+          "gamma": {
+            "maxLength": 50,
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -6,8 +6,10 @@ import { computed, inject } from 'vue'
 
 import ScreenReader from '@/components/ScreenReader.vue'
 import type { Schemas } from '@/features/Operation/types/schemas'
+import { useConfig } from '@/hooks/useConfig'
 import { DISCRIMINATOR_CONTEXT } from '@/hooks/useDiscriminator'
 
+import { sortSchemaProperties } from './helpers/sort-schema-properties'
 import SchemaHeading from './SchemaHeading.vue'
 import SchemaProperty from './SchemaProperty.vue'
 
@@ -51,6 +53,9 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void
 }>()
+
+// Get configuration for property sorting
+const config = useConfig()
 
 // Inject the discriminator context
 const discriminatorContext = inject(DISCRIMINATOR_CONTEXT, null)
@@ -143,6 +148,33 @@ const shouldShowDescription = computed(() => {
   }
 
   return true
+})
+
+/**
+ * Sorts schema property keys based on configuration settings.
+ * Applies alphabetical or preserved ordering, with optional required-first grouping.
+ */
+const sortedPropertyKeys = computed(() => {
+  if (
+    !schema.value ||
+    typeof schema.value !== 'object' ||
+    !('properties' in schema.value)
+  ) {
+    return []
+  }
+
+  const properties = schema.value.properties
+  if (!properties) {
+    return []
+  }
+
+  const propertyKeys = Object.keys(properties)
+  const requiredProperties = schema.value.required || []
+
+  return sortSchemaProperties(propertyKeys, requiredProperties, {
+    orderSchemaPropertiesBy: config.value.orderSchemaPropertiesBy,
+    orderRequiredPropertiesFirst: config.value.orderRequiredPropertiesFirst,
+  })
 })
 
 // Prevent click action if noncollapsible
@@ -246,7 +278,7 @@ const handleDiscriminatorChange = (type: string) => {
             <!-- Regular properties -->
             <template v-if="schema.properties">
               <SchemaProperty
-                v-for="property in Object.keys(schema.properties)"
+                v-for="property in sortedPropertyKeys"
                 :key="property"
                 :compact="compact"
                 :hideHeading="hideHeading"

--- a/packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import { sortSchemaProperties } from './sort-schema-properties'
+
+describe('sortSchemaProperties', () => {
+  const propertyKeys = ['zebra', 'beta', 'alpha', 'gamma']
+  const requiredProperties = ['gamma', 'zebra']
+
+  describe('Case 1: alpha + orderRequiredPropertiesFirst (default)', () => {
+    it('sorts required properties alphabetically first, then optional properties alphabetically', () => {
+      const result = sortSchemaProperties(propertyKeys, requiredProperties, {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['gamma', 'zebra', 'alpha', 'beta'])
+    })
+
+    it('handles empty required properties', () => {
+      const result = sortSchemaProperties(propertyKeys, [], {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['alpha', 'beta', 'gamma', 'zebra'])
+    })
+
+    it('handles all properties being required', () => {
+      const result = sortSchemaProperties(propertyKeys, propertyKeys, {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['alpha', 'beta', 'gamma', 'zebra'])
+    })
+  })
+
+  describe('Case 2: alpha + !orderRequiredPropertiesFirst', () => {
+    it('sorts all properties alphabetically regardless of required status', () => {
+      const result = sortSchemaProperties(propertyKeys, requiredProperties, {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: false,
+      })
+
+      expect(result).toEqual(['alpha', 'beta', 'gamma', 'zebra'])
+    })
+  })
+
+  describe('Case 3: preserve + orderRequiredPropertiesFirst', () => {
+    it('preserves order but shows required properties first', () => {
+      const result = sortSchemaProperties(propertyKeys, requiredProperties, {
+        orderSchemaPropertiesBy: 'preserve',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['zebra', 'gamma', 'beta', 'alpha'])
+    })
+
+    it('handles empty required properties', () => {
+      const result = sortSchemaProperties(propertyKeys, [], {
+        orderSchemaPropertiesBy: 'preserve',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['zebra', 'beta', 'alpha', 'gamma'])
+    })
+  })
+
+  describe('Case 4: preserve + !orderRequiredPropertiesFirst', () => {
+    it('preserves original order for all properties', () => {
+      const result = sortSchemaProperties(propertyKeys, requiredProperties, {
+        orderSchemaPropertiesBy: 'preserve',
+        orderRequiredPropertiesFirst: false,
+      })
+
+      expect(result).toEqual(['zebra', 'beta', 'alpha', 'gamma'])
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles empty property keys', () => {
+      const result = sortSchemaProperties([], requiredProperties, {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual([])
+    })
+
+    it('handles single property', () => {
+      const result = sortSchemaProperties(['single'], ['single'], {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['single'])
+    })
+
+    it('does not mutate original array', () => {
+      const original = ['zebra', 'beta', 'alpha', 'gamma']
+      sortSchemaProperties(original, requiredProperties, {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(original).toEqual(['zebra', 'beta', 'alpha', 'gamma'])
+    })
+
+    it('handles properties with special characters', () => {
+      const specialProps = ['_private', 'public', '$special', 'normal']
+      const result = sortSchemaProperties(specialProps, ['$special'], {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: true,
+      })
+
+      expect(result).toEqual(['$special', '_private', 'normal', 'public'])
+    })
+
+    it('handles case-sensitive sorting', () => {
+      const caseProps = ['Zebra', 'apple', 'Banana', 'cherry']
+      const result = sortSchemaProperties(caseProps, [], {
+        orderSchemaPropertiesBy: 'alpha',
+        orderRequiredPropertiesFirst: false,
+      })
+
+      // localeCompare handles case-insensitive sorting by default
+      expect(result).toEqual(['apple', 'Banana', 'cherry', 'Zebra'])
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/sort-schema-properties.ts
@@ -1,0 +1,90 @@
+/**
+ * Configuration options for sorting schema properties
+ */
+export type PropertySortingConfig = {
+  /** How to sort properties: alphabetically or preserve original order */
+  orderSchemaPropertiesBy: 'alpha' | 'preserve'
+  /** Whether to show required properties first */
+  orderRequiredPropertiesFirst: boolean
+}
+
+/**
+ * Sorts schema property keys based on the provided configuration options.
+ *
+ * The function handles four different sorting combinations:
+ * 1. alpha + requiredFirst: Required properties alphabetically, then optional properties alphabetically
+ * 2. alpha + !requiredFirst: All properties sorted alphabetically together
+ * 3. preserve + requiredFirst: Required properties in original order, then optional properties in original order
+ * 4. preserve + !requiredFirst: All properties in their original order (no sorting)
+ *
+ * @param propertyKeys - Array of property keys to sort
+ * @param requiredProperties - Array of property keys that are marked as required
+ * @param config - Sorting configuration options
+ * @returns Sorted array of property keys
+ *
+ * @example
+ * ```ts
+ * const properties = ['zebra', 'beta', 'alpha', 'gamma']
+ * const required = ['gamma', 'zebra']
+ *
+ * // Case 1: alpha + requiredFirst (default)
+ * sortSchemaProperties(properties, required, {
+ *   orderSchemaPropertiesBy: 'alpha',
+ *   orderRequiredPropertiesFirst: true
+ * })
+ * // Result: ['gamma', 'zebra', 'alpha', 'beta']
+ *
+ * // Case 2: alpha + !requiredFirst
+ * sortSchemaProperties(properties, required, {
+ *   orderSchemaPropertiesBy: 'alpha',
+ *   orderRequiredPropertiesFirst: false
+ * })
+ * // Result: ['alpha', 'beta', 'gamma', 'zebra']
+ *
+ * // Case 3: preserve + requiredFirst
+ * sortSchemaProperties(properties, required, {
+ *   orderSchemaPropertiesBy: 'preserve',
+ *   orderRequiredPropertiesFirst: true
+ * })
+ * // Result: ['zebra', 'gamma', 'beta', 'alpha']
+ *
+ * // Case 4: preserve + !requiredFirst
+ * sortSchemaProperties(properties, required, {
+ *   orderSchemaPropertiesBy: 'preserve',
+ *   orderRequiredPropertiesFirst: false
+ * })
+ * // Result: ['zebra', 'beta', 'alpha', 'gamma']
+ * ```
+ */
+export function sortSchemaProperties(
+  propertyKeys: string[],
+  requiredProperties: string[] = [],
+  config: PropertySortingConfig,
+): string[] {
+  const { orderSchemaPropertiesBy, orderRequiredPropertiesFirst } = config
+
+  // Case 4: preserve order and do not separate required/optional
+  if (orderSchemaPropertiesBy === 'preserve' && !orderRequiredPropertiesFirst) {
+    return [...propertyKeys]
+  }
+
+  // Case 2: sort alphabetically but do not separate required/optional
+  if (orderSchemaPropertiesBy === 'alpha' && !orderRequiredPropertiesFirst) {
+    return [...propertyKeys].sort((a, b) => a.localeCompare(b))
+  }
+
+  // For the remaining cases, we need to separate required and optional properties
+  const requiredSet = new Set(requiredProperties)
+  const required = propertyKeys.filter((key) => requiredSet.has(key))
+  const optional = propertyKeys.filter((key) => !requiredSet.has(key))
+
+  // Case 3: preserve order but show required first
+  if (orderSchemaPropertiesBy === 'preserve' && orderRequiredPropertiesFirst) {
+    return [...required, ...optional]
+  }
+
+  // Case 1: sort alphabetically and show required first (default behavior)
+  const sortedRequired = [...required].sort((a, b) => a.localeCompare(b))
+  const sortedOptional = [...optional].sort((a, b) => a.localeCompare(b))
+  return [...sortedRequired, ...sortedOptional]
+}

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -454,6 +454,18 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
     operationsSorter: z
       .union([z.literal('alpha'), z.literal('method'), z.function().args(z.any(), z.any()).returns(z.number())])
       .optional(),
+    /**
+     * Controls how schema properties are sorted in the documentation
+     * @default 'alpha' for alphabetical sorting
+     */
+    orderSchemaPropertiesBy: z.enum(['alpha', 'preserve']).optional().default('alpha').catch('alpha'),
+    /**
+     * When true, required properties are displayed first (in their sorted order),
+     * followed by optional properties (in their sorted order).
+     * When false, all properties are sorted together regardless of required status.
+     * @default true
+     */
+    orderRequiredPropertiesFirst: z.boolean().optional().default(true).catch(true),
   }),
 )
 


### PR DESCRIPTION
**Problem**

Currently, the order in which properties are displayed is not implemented, which can impact the developer experience. Some users prefer **alphabetical sorting** for easier scanning, others want **required properties highlighted at the top**, and some need to **preserve the exact order from their OpenAPI specifications** to emphasize important fields or maintain logical groups. 

**Solution**

With this PR, the logic to sort properties based on the new configurations has been implemented. `orderSchemaPropertiesBy` accepts either`'alpha'` (default) to sort in alphabetical order or `'preserve'`  to preserve the original order. `orderRequiredPropertiesFirst` is a boolean where if '`true`' (default), required properties will be grouped first before the optional properties. The combination of these two configurations displays the properties in different order, as shown in the issue description. 

**Screenshot of test suite output**
<img width="809" height="599" alt="Screenshot 2025-11-02 at 1 46 35 PM" src="https://github.com/user-attachments/assets/fff95805-d8ab-441b-82cf-d5d50dc33ca9" />

[**Video Walkthrough**](https://cap.link/k3xmmaeqm6y533e)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
