### PR TITLE
Replace select element with ScalarCombobox

### DIFF
--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 import { Tab } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import {
+  ScalarCombobox,
+  ScalarIcon,
+  type ScalarComboboxOption,
+  type ScalarComboboxOptionGroup,
+} from '@scalar/components'
 import type { TargetId } from '@scalar/types/snippetz'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { useFeaturedHttpClients } from '@/components/Content/ClientLibraries/useFeaturedHttpClients'
 import {
@@ -41,6 +46,53 @@ const isSelectedClient = (language: HttpClientState) => {
     language.clientKey === httpClient.clientKey
   )
 }
+
+/**
+ * Convert availableTargets to OptionGroup[] format for ScalarCombobox
+ */
+const comboboxOptions = computed<ScalarComboboxOptionGroup[]>(() =>
+  availableTargets.value.map((target) => ({
+    label: target.title,
+    options: target.clients.map((client) => ({
+      id: `${target.key}-${client.client}`,
+      label: getClientTitle({
+        targetKey: target.key,
+        clientKey: client.client,
+      }),
+      targetKey: target.key,
+      clientKey: client.client,
+    })),
+  })),
+)
+
+/**
+ * The currently selected option for the combobox
+ * Format conversion for ScalarCombobox where the v-model expects and Option object
+ */
+const selectedOption = computed<ScalarComboboxOption | undefined>(() => {
+  if (!httpClient) return undefined
+
+  return {
+    id: `${httpClient.targetKey}-${httpClient.clientKey}`,
+    label: getClientTitle(httpClient),
+    targetKey: httpClient.targetKey,
+    clientKey: httpClient.clientKey,
+  }
+})
+
+/**
+ * Handle combobox selection change
+ */
+const handleComboboxChange = (
+  option: ScalarComboboxOption & { targetKey?: string; clientKey?: string },
+) => {
+  if (option.targetKey && option.clientKey) {
+    setHttpClient({
+      targetKey: option.targetKey as TargetId,
+      clientKey: option.clientKey,
+    })
+  }
+}
 </script>
 <template>
   <div
@@ -60,79 +112,55 @@ const isSelectedClient = (language: HttpClientState) => {
       </div>
       <span class="client-libraries-text">{{ getTargetTitle(client) }}</span>
     </Tab>
-    <label
-      class="client-libraries client-libraries__select"
-      :class="{
-        'client-libraries__active': httpClient && !isFeatured(httpClient),
-      }">
-      <select
-        :aria-controls="morePanel"
-        class="language-select"
-        :value="JSON.stringify(httpClient)"
-        @input="
-          (event) =>
-            setHttpClient(JSON.parse((event.target as HTMLSelectElement).value))
-        ">
-        <optgroup
-          v-for="target in availableTargets"
-          :key="target.key"
-          :label="target.title">
-          <option
-            v-for="client in target.clients"
-            :key="client.client"
-            :aria-label="`${target.title} ${getClientTitle({
-              targetKey: target.key,
-              clientKey: client.client,
-            })}`"
-            :value="
-              JSON.stringify({
-                targetKey: target.key,
-                clientKey: client.client,
-              })
-            ">
-            {{
-              getClientTitle({
-                targetKey: target.key,
-                clientKey: client.client,
-              })
-            }}
-          </option>
-        </optgroup>
-      </select>
-      <div
-        aria-hidden="true"
-        class="client-libraries-icon__more">
-        <template v-if="httpClient && !isFeatured(httpClient)">
-          <div :class="`client-libraries-icon__${httpClient.targetKey}`">
-            <ScalarIcon
+    <ScalarCombobox
+      :modelValue="selectedOption"
+      :options="comboboxOptions"
+      placeholder="Search languages..."
+      placement="bottom-end"
+      :teleport="true"
+      @update:modelValue="handleComboboxChange">
+      <button
+        type="button"
+        class="client-libraries client-libraries__select"
+        :class="{
+          'client-libraries__active': httpClient && !isFeatured(httpClient),
+        }"
+        :aria-controls="morePanel">
+        <div
+          aria-hidden="true"
+          class="client-libraries-icon__more">
+          <template v-if="httpClient && !isFeatured(httpClient)">
+            <div :class="`client-libraries-icon__${httpClient.targetKey}`">
+              <ScalarIcon
+                class="client-libraries-icon"
+                :icon="getIconByLanguageKey(httpClient.targetKey)" />
+            </div>
+          </template>
+          <template v-else>
+            <svg
               class="client-libraries-icon"
-              :icon="getIconByLanguageKey(httpClient.targetKey)" />
-          </div>
-        </template>
-        <template v-else>
-          <svg
-            class="client-libraries-icon"
-            height="50"
-            role="presentation"
-            viewBox="0 0 50 50"
-            width="50"
-            xmlns="http://www.w3.org/2000/svg">
-            <g
-              fill="currentColor"
-              fill-rule="nonzero">
-              <path
-                d="M10.71 25.3a3.87 3.87 0 1 0 7.74 0 3.87 3.87 0 0 0-7.74 0M21.13 25.3a3.87 3.87 0 1 0 7.74 0 3.87 3.87 0 0 0-7.74 0M31.55 25.3a3.87 3.87 0 1 0 7.74 0 3.87 3.87 0 0 0-7.74 0" />
-            </g>
-          </svg>
-        </template>
-      </div>
-      <span
-        v-if="availableTargets.length"
-        class="client-libraries-text client-libraries-text-more">
-        More
-      </span>
-      <span class="sr-only">Select from all clients</span>
-    </label>
+              height="50"
+              role="presentation"
+              viewBox="0 0 50 50"
+              width="50"
+              xmlns="http://www.w3.org/2000/svg">
+              <g
+                fill="currentColor"
+                fill-rule="nonzero">
+                <path
+                  d="M10.71 25.3a3.87 3.87 0 1 0 7.74 0 3.87 3.87 0 0 0-7.74 0M21.13 25.3a3.87 3.87 0 1 0 7.74 0 3.87 3.87 0 0 0-7.74 0M31.55 25.3a3.87 3.87 0 1 0 7.74 0 3.87 3.87 0 0 0-7.74 0" />
+              </g>
+            </svg>
+          </template>
+        </div>
+        <span
+          v-if="availableTargets.length"
+          class="client-libraries-text client-libraries-text-more">
+          More
+        </span>
+        <span class="sr-only">Select from all clients</span>
+      </button>
+    </ScalarCombobox>
   </div>
 </template>
 <style scoped>
@@ -244,22 +272,11 @@ const isSelectedClient = (language: HttpClientState) => {
   color: var(--scalar-color-1);
   font-weight: var(--scalar-semibold);
 }
-.client-libraries__select select {
-  background: var(--scalar-background-3);
-  color: var(--scalar-color-2);
-  opacity: 0;
-  height: 100%;
-  width: 100%;
-  aspect-ratio: 1;
-  position: absolute;
-  top: 0;
-  left: 0;
-  cursor: pointer;
-  z-index: 1;
-  appearance: none;
+.client-libraries__select {
+  background: transparent;
   border: none;
 }
-.client-libraries__select:has(select:focus-visible) {
+.client-libraries__select:focus-visible {
   border-radius: var(--scalar-radius);
   box-shadow: inset 0 0 0 1px var(--scalar-color-accent);
 }


### PR DESCRIPTION
**Problem**

Currently, the UI for the client library dropdown under 'more' does not match with the Scalar's aesthetics, which can hinder user experience. The drop down uses the 'select' element, which provides a default drop down. 

**Solution**

With this PR, the 'select' element was replaced with ScalarCombobox to match Scalar's UI. This change also came with modifying props in order to handle proper parameter passing to ScalarCombobox. The functionality is the same, except a search function was added to the dropdown. 

[Video Walkthrough](https://cap.link/r7nkwrygp6kjcvt)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
